### PR TITLE
feat: add OpenAI-compatible provider support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,14 @@
 
 # Stremio AI Search
 
-An intelligent search addon for Stremio powered by Google's Gemini AI. Get personalized movie and TV series recommendations based on natural language queries.
+An intelligent search addon for Stremio powered by AI (Gemini-compatible or any OpenAI-compatible provider like OpenAI, OpenRouter, Z.ai). Get personalized movie and TV series recommendations based on natural language queries.
 
 <img src="https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fstremio.itcon.au%2Faisearch%2Fstats%2Fcount%3Fformat%3Djson&query=%24.count&label=Recommendations%20served&color=blue" alt="Recommendations served" />
 
 ## Features
 
-- Trakt integration to help Gemini suggest personalized recommendations. Note: Only searches starting with "Recommend" will provide personalized recommendations using your watch history from Trakt.
-- Select any of the Google AI models in the addon configuration
+- Trakt integration to help the AI suggest personalized recommendations. Note: Only searches starting with "Recommend" will provide personalized recommendations using your watch history from Trakt.
+- Choose between Gemini-compatible and OpenAI-compatible models (provider + model are configurable)
 - You can set the number of recommendations AI should return for a query (30 Max)
 - TMDB integration ensures you have a content rich catalog for movies and series
 - RPDB integration gives you access to awesome posters with inbuilt ratings
@@ -31,6 +31,15 @@ An intelligent search addon for Stremio powered by Google's Gemini AI. Get perso
    <a href="https://buymeacoffee.com/itcon">
    <img src="public/bmc.png" alt="Buy Me A Coffee" height="40" />
    </a>
+
+## AI Provider Setup
+
+In the configuration page you can choose an AI provider:
+
+- **Gemini**: use a key from Google AI Studio and a Gemini model id (e.g. `gemini-2.5-flash-lite`)
+- **OpenAI-compatible**: works with OpenAI / OpenRouter / Z.ai / other OpenAI-compatible APIs
+  - Base URL examples: `https://api.openai.com`, `https://openrouter.ai/api`
+  - Model examples: `gpt-4o-mini`, `openai/gpt-4o-mini` (OpenRouter-style)
 
 ## Customizing Your Homepage
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ In the configuration page you can choose an AI provider:
 - **OpenAI-compatible**: works with OpenAI / OpenRouter / Z.ai / other OpenAI-compatible APIs
   - Base URL examples: `https://api.openai.com`, `https://openrouter.ai/api`
   - Model examples: `gpt-4o-mini`, `openai/gpt-4o-mini` (OpenRouter-style)
+  - Optional extra headers (JSON): `{"HTTP-Referer":"https://example.com","X-Title":"Stremio AI Search"}`
 
 ## Customizing Your Homepage
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ In the configuration page you can choose an AI provider:
   - Model examples: `gpt-4o-mini`, `openai/gpt-4o-mini` (OpenRouter-style)
   - Optional extra headers (JSON): `{"HTTP-Referer":"https://example.com","X-Title":"Stremio AI Search"}`
 
+Advanced option:
+- **AI Temperature**: controls randomness (lower is more deterministic; default `0.2`)
+
 ## Customizing Your Homepage
 
 One of the most powerful features of this addon is the ability to create your own recommendation rows directly on the Stremio homepage. In the "Custom Homepage Catalogs" field within the addon's advanced settings, you can define multiple, comma-separated catalogs.

--- a/addon.js
+++ b/addon.js
@@ -2804,7 +2804,7 @@ const catalogHandler = async function (args, req) {
       traktAccessTokenLength: configData.TraktAccessToken?.length || 0,
     });
 
-    const geminiModel = aiProviderConfig.model;
+    const aiModel = aiProviderConfig.model;
     const language = configData.TmdbLanguage || "en-US";
 
     if (!aiApiKey || aiApiKey.length < 10) {
@@ -2851,7 +2851,7 @@ const catalogHandler = async function (args, req) {
         enableAiCache: enableAiCache,
         enableRpdb: enableRpdb,
         includeAdult: includeAdult,
-        aiModel: geminiModel,
+        aiModel: aiModel,
         language: language,
         hasTraktClientId: !!DEFAULT_TRAKT_CLIENT_ID,
         hasTraktAccessToken: !!configData.TraktAccessToken,
@@ -3075,7 +3075,7 @@ const catalogHandler = async function (args, req) {
         cacheKey,
         query: searchQuery,
         type,
-        model: geminiModel,
+        model: aiModel,
         cachedAt: new Date(cached.timestamp).toISOString(),
         age: `${Math.round((Date.now() - cached.timestamp) / 1000)}s`,
         responseTime: `${Date.now() - startTime}ms`,
@@ -3117,7 +3117,7 @@ const catalogHandler = async function (args, req) {
           logger.error("AI returned no valid recommendations", { 
             query: searchQuery, 
             type: type,
-            model: geminiModel,
+            model: aiModel,
             responseText: text
           });
           const errorMeta = createErrorMeta('No Results Found', 'The AI could not find any recommendations for your query. Please try rephrasing your search.');
@@ -3504,7 +3504,7 @@ const catalogHandler = async function (args, req) {
 
       logger.info("Making AI API call", {
         provider: aiClient.provider,
-        model: geminiModel,
+        model: aiModel,
         query: searchQuery,
         type,
         prompt: promptText,

--- a/addon.js
+++ b/addon.js
@@ -5,6 +5,10 @@ const logger = require("./utils/logger");
 const path = require("path");
 const { decryptConfig } = require("./utils/crypto");
 const { withRetry } = require("./utils/apiRetry");
+const {
+  createAiTextGenerator,
+  getAiProviderConfigFromConfig,
+} = require("./utils/aiProvider");
 const TMDB_API_BASE = "https://api.themoviedb.org/3";
 const TMDB_CACHE_DURATION = 7 * 24 * 60 * 60 * 1000; // 7 day cache for TMDB
 const TMDB_DISCOVER_CACHE_DURATION = 7 * 24 * 60 * 60 * 1000; // 7 day cache for TMDB discover (was 12 hours)
@@ -2448,14 +2452,10 @@ function deserializeAllCaches(data) {
 /**
  * Makes an AI call to determine the content type and genres for a recommendation query
  * @param {string} query - The user's search query
- * @param {string} geminiKey - The Gemini API key
- * @param {string} geminiModel - The Gemini model to use
+ * @param {{ provider: string, model: string, generateText: (prompt: string) => Promise<string> }} aiClient
  * @returns {Promise<{type: string, genres: string[]}>} - The discovered type and genres
  */
-async function discoverTypeAndGenres(query, geminiKey, geminiModel) {
-  const genAI = new GoogleGenerativeAI(geminiKey);
-  const model = genAI.getGenerativeModel({ model: geminiModel });
-
+async function discoverTypeAndGenres(query, aiClient) {
   const promptText = `
 Analyze this recommendation query: "${query}"
 
@@ -2484,35 +2484,27 @@ Do not include any explanatory text before or after your response. Just the sing
   try {
     logger.info("Making genre discovery API call", {
       query,
-      model: geminiModel,
+      provider: aiClient?.provider,
+      model: aiClient?.model,
     });
 
-    // Use withRetry for the Gemini API call
+    // Use withRetry for the AI API call
     const text = await withRetry(
       async () => {
         try {
-          const aiResult = await model.generateContent(promptText);
-          const response = await aiResult.response;
-          const responseText = response.text().trim();
-
-          // Log successful response with more details
+          const responseText = await aiClient.generateText(promptText);
           logger.info("Genre discovery API response", {
-            promptTokens: aiResult.promptFeedback?.tokenCount,
-            candidates: aiResult.candidates?.length,
-            safetyRatings: aiResult.candidates?.[0]?.safetyRatings,
             responseTextLength: responseText.length,
             responseTextSample: responseText,
           });
-
           return responseText;
         } catch (error) {
-          // Enhance error with status for retry logic
           logger.error("Genre discovery API call failed", {
             error: error.message,
-            status: error.httpStatus || 500,
+            status: error.status || error.httpStatus || 500,
             stack: error.stack,
           });
-          error.status = error.httpStatus || 500;
+          error.status = error.status || error.httpStatus || 500;
           throw error;
         }
       },
@@ -2522,7 +2514,7 @@ Do not include any explanatory text before or after your response. Just the sing
         maxDelay: 10000,
         // Don't retry 400 errors (bad requests)
         shouldRetry: (error) => !error.status || error.status !== 400,
-        operationName: "Genre discovery API call",
+        operationName: "AI genre discovery call",
       }
     );
 
@@ -2700,8 +2692,21 @@ const catalogHandler = async function (args, req) {
       return { metas: [errorMeta] };
     }
 
-    const geminiKey = configData.GeminiApiKey;
     const tmdbKey = configData.TmdbApiKey;
+    const aiProviderConfig = getAiProviderConfigFromConfig(configData);
+    const aiApiKey = aiProviderConfig.apiKey;
+    let aiClient;
+
+    try {
+      aiClient = createAiTextGenerator(aiProviderConfig);
+    } catch (error) {
+      logger.error("AI provider configuration error", { error: error.message });
+      const errorMeta = createErrorMeta(
+        "AI Provider Configuration Error",
+        "The selected AI provider is misconfigured. Please review your addon settings."
+      );
+      return { metas: [errorMeta] };
+    }
 
     if (configData.traktConnectionError) {
       logger.error('Trakt Connection Failed', { reason: 'User access to Trakt.tv has expired or was revoked.' });
@@ -2720,9 +2725,18 @@ const catalogHandler = async function (args, req) {
       const errorMeta = createErrorMeta('TMDB API Key Invalid', `The key failed validation (Status: ${tmdbResponse.status}). Please check your TMDB key in the addon settings.`);
       return { metas: [errorMeta] };
     }
-    if (!geminiKey || geminiKey.length < 10) {
-      logger.error('Gemini API Key Invalid', { reason: 'Your Gemini API key is missing or invalid.' });
-      const errorMeta = createErrorMeta('Gemini API Key Invalid', 'Your Gemini API key is missing or invalid. Please correct it in the addon settings.');
+    if (!aiApiKey || aiApiKey.length < 10) {
+      const providerName =
+        aiProviderConfig.provider === "openai-compat"
+          ? "OpenAI-Compatible"
+          : "Gemini";
+      logger.error(`${providerName} API Key Invalid`, {
+        reason: `Your ${providerName} API key is missing or invalid.`,
+      });
+      const errorMeta = createErrorMeta(
+        `${providerName} API Key Invalid`,
+        `Your ${providerName} API key is missing or invalid. Please correct it in the addon settings.`
+      );
       return { metas: [errorMeta] };
     }
 
@@ -2790,16 +2804,14 @@ const catalogHandler = async function (args, req) {
       traktAccessTokenLength: configData.TraktAccessToken?.length || 0,
     });
 
-    const geminiModel = configData.GeminiModel || DEFAULT_GEMINI_MODEL;
+    const geminiModel = aiProviderConfig.model;
     const language = configData.TmdbLanguage || "en-US";
 
-    if (!geminiKey || geminiKey.length < 10) {
-      logger.error("Invalid or missing Gemini API key");
-      return {
-        metas: [],
-        error:
-          "Invalid Gemini API key. Please reconfigure the addon with a valid key.",
-      };
+    if (!aiApiKey || aiApiKey.length < 10) {
+      logger.error("Invalid or missing AI provider API key", {
+        aiProvider: aiProviderConfig.provider,
+      });
+      return { metas: [], error: "Invalid AI provider API key. Please reconfigure the addon with a valid key." };
     }
 
     if (!tmdbKey || tmdbKey.length < 10) {
@@ -2830,7 +2842,8 @@ const catalogHandler = async function (args, req) {
         numResults,
         rawNumResults: configData.NumResults,
         type,
-        hasGeminiKey: !!geminiKey,
+        aiProvider: aiProviderConfig.provider,
+        hasAiKey: !!aiApiKey,
         hasTmdbKey: !!tmdbKey,
         hasRpdbKey: !!rpdbKey,
         isDefaultRpdbKey: rpdbKey === DEFAULT_RPDB_KEY,
@@ -2838,14 +2851,14 @@ const catalogHandler = async function (args, req) {
         enableAiCache: enableAiCache,
         enableRpdb: enableRpdb,
         includeAdult: includeAdult,
-        geminiModel: geminiModel,
+        aiModel: geminiModel,
         language: language,
         hasTraktClientId: !!DEFAULT_TRAKT_CLIENT_ID,
         hasTraktAccessToken: !!configData.TraktAccessToken,
       });
     }
 
-    if (!geminiKey || !tmdbKey) {
+    if (!aiApiKey || !tmdbKey) {
       logger.error("Missing API keys in catalog handler");
       logger.emptyCatalog("Missing API keys", { type, extra });
       return { metas: [] };
@@ -2948,8 +2961,7 @@ const catalogHandler = async function (args, req) {
       // Make the genre discovery API call
       const discoveryResult = await discoverTypeAndGenres(
         searchQuery,
-        geminiKey,
-        geminiModel
+        aiClient
       );
       discoveredGenres = discoveryResult.genres;
 
@@ -3200,8 +3212,6 @@ const catalogHandler = async function (args, req) {
     }
 
     try {
-      const genAI = new GoogleGenerativeAI(geminiKey);
-      const model = genAI.getGenerativeModel({ model: geminiModel });
       const genreCriteria = extractGenreCriteria(searchQuery);
       const currentYear = new Date().getFullYear();
 
@@ -3492,7 +3502,8 @@ const catalogHandler = async function (args, req) {
 
       promptText = promptText.join("\n");
 
-      logger.info("Making Gemini API call", {
+      logger.info("Making AI API call", {
+        provider: aiClient.provider,
         model: geminiModel,
         query: searchQuery,
         type,
@@ -3501,19 +3512,13 @@ const catalogHandler = async function (args, req) {
         numResults,
       });
 
-      // Use withRetry for the Gemini API call
+      // Use withRetry for the AI API call
       const text = await withRetry(
         async () => {
           try {
-            const aiResult = await model.generateContent(promptText);
-            const response = await aiResult.response;
-            const responseText = response.text().trim();
-
-            logger.info("Gemini API response", {
+            const responseText = await aiClient.generateText(promptText);
+            logger.info("AI API response", {
               duration: `${Date.now() - startTime}ms`,
-              promptTokens: aiResult.promptFeedback?.tokenCount,
-              candidates: aiResult.candidates?.length,
-              safetyRatings: aiResult.candidates?.[0]?.safetyRatings,
               responseTextLength: responseText.length,
               responseTextSample:
                 responseText.substring(0, 100) +
@@ -3522,12 +3527,12 @@ const catalogHandler = async function (args, req) {
 
             return responseText;
           } catch (error) {
-            logger.error("Gemini API call failed", {
+            logger.error("AI API call failed", {
               error: error.message,
-              status: error.httpStatus || 500,
+              status: error.status || error.httpStatus || 500,
               stack: error.stack,
             });
-            error.status = error.httpStatus || 500;
+            error.status = error.status || error.httpStatus || 500;
             throw error;
           }
         },
@@ -3537,7 +3542,7 @@ const catalogHandler = async function (args, req) {
           maxDelay: 10000,
           // Don't retry 400 errors (bad requests)
           shouldRetry: (error) => !error.status || error.status !== 400,
-          operationName: "Gemini API call",
+          operationName: "AI API call",
         }
       );
 
@@ -3881,14 +3886,44 @@ const catalogHandler = async function (args, req) {
 
       return { metas: finalMetas };
     } catch (error) {
-      logger.error("Gemini API Error:", { error: error.message, stack: error.stack, query: searchQuery });
+      logger.error("AI API Error:", {
+        error: error.message,
+        status: error.status || error.httpStatus,
+        stack: error.stack,
+        query: searchQuery,
+        aiProvider: aiProviderConfig?.provider,
+      });
       let errorMessage = 'The AI model failed to respond. This may be a temporary issue.';
-      if (error.message.includes('400') || error.message.includes('API key not valid')) {
-        errorMessage = 'Your Gemini API key is invalid or has been revoked. Please update it in the settings.';
-      } else if (error.message.includes('quota')) {
-        errorMessage = 'You have exceeded your Gemini API quota for the day. Please check your Google AI Studio account.';
-      } else if (error.message.includes('404')) {
-          errorMessage = 'The selected Gemini Model is invalid or not found. Please try a different model in the settings.';
+
+      const status = error.status || error.httpStatus;
+      const provider = aiProviderConfig?.provider;
+
+      const isAuthError =
+        status === 401 ||
+        status === 403 ||
+        (typeof error.message === "string" &&
+          /api key|unauthorized|forbidden/i.test(error.message));
+      const isRateLimit =
+        status === 429 ||
+        (typeof error.message === "string" && /quota|rate limit/i.test(error.message));
+      const isNotFound =
+        status === 404 || (typeof error.message === "string" && /not found/i.test(error.message));
+
+      if (isAuthError) {
+        errorMessage =
+          provider === "openai-compat"
+            ? "Your OpenAI-compatible API key is invalid or has been revoked. Please update it in the settings."
+            : "Your Gemini API key is invalid or has been revoked. Please update it in the settings.";
+      } else if (isRateLimit) {
+        errorMessage =
+          provider === "openai-compat"
+            ? "You have exceeded your OpenAI-compatible provider quota/rate limit. Please check your provider account."
+            : "You have exceeded your Gemini API quota for the day. Please check your Google AI Studio account.";
+      } else if (isNotFound) {
+        errorMessage =
+          provider === "openai-compat"
+            ? "The selected model was not found. Please try a different model name in the settings."
+            : "The selected Gemini Model is invalid or not found. Please try a different model in the settings.";
       }
       const errorMeta = createErrorMeta('AI Error', errorMessage);
       return { metas: [errorMeta] };
@@ -3950,7 +3985,9 @@ const metaHandler = async function (args) {
         throw new Error("Failed to decrypt config data in metaHandler");
       }
       const configData = JSON.parse(decryptedConfigStr);
-      const { GeminiApiKey, TmdbApiKey, GeminiModel, NumResults, RpdbApiKey, RpdbPosterType, TmdbLanguage, FanartApiKey } = configData;
+      const { TmdbApiKey, NumResults, FanartApiKey } = configData;
+      const aiProviderConfig = getAiProviderConfigFromConfig(configData);
+      const aiClient = createAiTextGenerator(aiProviderConfig);
 
       const originalId = id.split(':')[1];
       
@@ -4014,23 +4051,24 @@ const metaHandler = async function (args) {
       movie|Zodiac|2007
       movie|Prisoners|2013
       `;
-
-      const genAI = new GoogleGenerativeAI(GeminiApiKey);
-      const model = genAI.getGenerativeModel({ model: GeminiModel || DEFAULT_GEMINI_MODEL });
       
-      const aiResult = await withRetry(
+      const responseText = await withRetry(
         async () => {
-          return await model.generateContent(promptText);
+          try {
+            return await aiClient.generateText(promptText);
+          } catch (error) {
+            error.status = error.status || error.httpStatus || 500;
+            throw error;
+          }
         },
         {
           maxRetries: 3,
-          baseDelay: 1000,
+          initialDelay: 1000,
           shouldRetry: (error) => !error.status || error.status !== 400,
-          operationName: "Gemini API call (similar content)"
+          operationName: "AI API call (similar content)"
         }
       );
       
-      const responseText = aiResult.response.text().trim();
       const lines = responseText.split('\n').map(line => line.trim()).filter(Boolean);
 
       const videoPromises = lines.map(async (line) => {

--- a/index.html
+++ b/index.html
@@ -154,8 +154,9 @@
       <h1>Stremio AI Search</h1>
 
       <p style="text-align: center">
-        An intelligent search addon for Stremio powered by Google's Gemini AI.
-        Get personalized movie and TV series recommendations based on natural
+        An intelligent search addon for Stremio powered by AI (Gemini-compatible
+        or any OpenAI-compatible provider like OpenAI, OpenRouter, Z.ai). Get
+        personalized movie and TV series recommendations based on natural
         language queries.
       </p>
 

--- a/public/configure.html
+++ b/public/configure.html
@@ -949,6 +949,23 @@
               Higher values may increase response time
             </div>
           </div>
+
+          <div class="form-group">
+            <label class="form-label" for="aiTemperature">AI Temperature</label>
+            <input
+              type="number"
+              id="aiTemperature"
+              placeholder="Default: 0.2"
+              min="0"
+              max="1"
+              step="0.1"
+              value="0.2"
+            />
+            <div class="help-text">
+              Controls randomness. Lower values are more deterministic and tend
+              to follow the required output format more reliably.
+            </div>
+          </div>
         </div>
 
         <div class="button-group">
@@ -1272,6 +1289,7 @@
             RpdbApiKey: document.getElementById("rpdbKey").value.trim(),
             FanartApiKey: document.getElementById("fanartKey").value.trim(),
             NumResults: parseInt(document.getElementById("numResults").value.trim()) || 20,
+            AiTemperature: parseFloat(document.getElementById("aiTemperature").value.trim()) || 0.2,
             EnableAiCache: document.getElementById("enableAiCache").checked,
             TmdbLanguage: document.getElementById("tmdbLanguage").value,
             EnableRpdb: document.getElementById("enableRpdbPosters").checked,
@@ -1379,6 +1397,7 @@
               OpenAICompatModel: openaiCompatModel,
               OpenAICompatBaseUrl: openaiCompatBaseUrl,
               OpenAICompatExtraHeaders: openaiCompatExtraHeaders,
+              AiTemperature: parseFloat(document.getElementById("aiTemperature").value.trim()) || 0.2,
               TmdbApiKey: tmdbKey,
               FanartApiKey: fanartKey,
               TraktAccessToken: traktAccessToken,
@@ -1493,6 +1512,9 @@
         document.getElementById("manual-url").style.display = "none";
       });
       document.getElementById("numResults").addEventListener("input", () => {
+        document.getElementById("manual-url").style.display = "none";
+      });
+      document.getElementById("aiTemperature").addEventListener("input", () => {
         document.getElementById("manual-url").style.display = "none";
       });
       // NEW: Add listener for the RPDB enable checkbox
@@ -1647,6 +1669,8 @@
                   config.TmdbLanguage;
               if (config.NumResults)
                 document.getElementById("numResults").value = config.NumResults;
+              if (config.AiTemperature !== undefined)
+                document.getElementById("aiTemperature").value = config.AiTemperature;
               if (config.EnableAiCache !== undefined)
                 document.getElementById("enableAiCache").checked =
                   config.EnableAiCache;
@@ -1702,6 +1726,7 @@
               if (
                 config.RpdbApiKey ||
                 config.NumResults ||
+                config.AiTemperature !== undefined ||
                 config.EnableAiCache !== undefined ||
                 config.TraktAccessToken ||
                 config.GeminiModel ||

--- a/public/configure.html
+++ b/public/configure.html
@@ -1244,6 +1244,13 @@
           .getElementById("openaiCompatExtraHeaders")
           .value.trim();
         const tmdbKey = document.getElementById("tmdbKey").value.trim();
+        const aiTemperatureRaw = document
+          .getElementById("aiTemperature")
+          .value.trim();
+        const aiTemperatureParsed = parseFloat(aiTemperatureRaw);
+        const aiTemperature = Number.isFinite(aiTemperatureParsed)
+          ? Math.max(0, Math.min(1, aiTemperatureParsed))
+          : 0.2;
         
         // Basic validation
         if (aiProvider === "gemini") {
@@ -1275,6 +1282,7 @@
             openaiCompatModel,
             openaiCompatBaseUrl,
             openaiCompatExtraHeaders,
+            aiTemperature,
             tmdbKey,
           });
           if (!isValid) return null;
@@ -1289,7 +1297,7 @@
             RpdbApiKey: document.getElementById("rpdbKey").value.trim(),
             FanartApiKey: document.getElementById("fanartKey").value.trim(),
             NumResults: parseInt(document.getElementById("numResults").value.trim()) || 20,
-            AiTemperature: parseFloat(document.getElementById("aiTemperature").value.trim()) || 0.2,
+            AiTemperature: aiTemperature,
             EnableAiCache: document.getElementById("enableAiCache").checked,
             TmdbLanguage: document.getElementById("tmdbLanguage").value,
             EnableRpdb: document.getElementById("enableRpdbPosters").checked,
@@ -1373,6 +1381,7 @@
         openaiCompatModel,
         openaiCompatBaseUrl,
         openaiCompatExtraHeaders,
+        aiTemperature,
         tmdbKey,
       }) {
         const errorDiv = document.getElementById("error");
@@ -1397,7 +1406,7 @@
               OpenAICompatModel: openaiCompatModel,
               OpenAICompatBaseUrl: openaiCompatBaseUrl,
               OpenAICompatExtraHeaders: openaiCompatExtraHeaders,
-              AiTemperature: parseFloat(document.getElementById("aiTemperature").value.trim()) || 0.2,
+              AiTemperature: typeof aiTemperature === "number" ? aiTemperature : 0.2,
               TmdbApiKey: tmdbKey,
               FanartApiKey: fanartKey,
               TraktAccessToken: traktAccessToken,

--- a/public/configure.html
+++ b/public/configure.html
@@ -629,6 +629,23 @@
               <code>https://openrouter.ai/api/v1</code>
             </div>
           </div>
+
+          <div class="form-group">
+            <label class="form-label" for="openaiCompatExtraHeaders"
+              >Extra Headers (Optional)</label
+            >
+            <textarea
+              id="openaiCompatExtraHeaders"
+              class="form-textarea"
+              placeholder='JSON object, e.g. {"HTTP-Referer":"https://example.com","X-Title":"Stremio AI Search"}'
+              rows="3"
+            ></textarea>
+            <div class="help-text">
+              Optional JSON headers to send with requests (some providers like
+              OpenRouter recommend <code>HTTP-Referer</code> and
+              <code>X-Title</code>). Don’t include <code>Authorization</code>.
+            </div>
+          </div>
         </div>
 
         <div class="form-group">
@@ -1171,6 +1188,7 @@
           "openaiCompatApiKey",
           "openaiCompatModel",
           "openaiCompatBaseUrl",
+          "openaiCompatExtraHeaders",
           "tmdbKey",
           "rpdbKey",
           "fanartKey",
@@ -1205,6 +1223,9 @@
         const openaiCompatBaseUrl = document
           .getElementById("openaiCompatBaseUrl")
           .value.trim();
+        const openaiCompatExtraHeaders = document
+          .getElementById("openaiCompatExtraHeaders")
+          .value.trim();
         const tmdbKey = document.getElementById("tmdbKey").value.trim();
         
         // Basic validation
@@ -1236,6 +1257,7 @@
             openaiCompatApiKey,
             openaiCompatModel,
             openaiCompatBaseUrl,
+            openaiCompatExtraHeaders,
             tmdbKey,
           });
           if (!isValid) return null;
@@ -1265,6 +1287,7 @@
             configData.OpenAICompatApiKey = openaiCompatApiKey;
             configData.OpenAICompatModel = openaiCompatModel;
             if (openaiCompatBaseUrl) configData.OpenAICompatBaseUrl = openaiCompatBaseUrl;
+            if (openaiCompatExtraHeaders) configData.OpenAICompatExtraHeaders = openaiCompatExtraHeaders;
           }
 
           // Add conditional properties
@@ -1331,6 +1354,7 @@
         openaiCompatApiKey,
         openaiCompatModel,
         openaiCompatBaseUrl,
+        openaiCompatExtraHeaders,
         tmdbKey,
       }) {
         const errorDiv = document.getElementById("error");
@@ -1354,6 +1378,7 @@
               OpenAICompatApiKey: openaiCompatApiKey,
               OpenAICompatModel: openaiCompatModel,
               OpenAICompatBaseUrl: openaiCompatBaseUrl,
+              OpenAICompatExtraHeaders: openaiCompatExtraHeaders,
               TmdbApiKey: tmdbKey,
               FanartApiKey: fanartKey,
               TraktAccessToken: traktAccessToken,
@@ -1456,6 +1481,9 @@
         document.getElementById("manual-url").style.display = "none";
       });
       document.getElementById("openaiCompatBaseUrl").addEventListener("input", () => {
+        document.getElementById("manual-url").style.display = "none";
+      });
+      document.getElementById("openaiCompatExtraHeaders").addEventListener("input", () => {
         document.getElementById("manual-url").style.display = "none";
       });
       document.getElementById("tmdbKey").addEventListener("input", () => {
@@ -1600,6 +1628,9 @@
               if (config.OpenAICompatBaseUrl)
                 document.getElementById("openaiCompatBaseUrl").value =
                   config.OpenAICompatBaseUrl;
+              if (config.OpenAICompatExtraHeaders)
+                document.getElementById("openaiCompatExtraHeaders").value =
+                  config.OpenAICompatExtraHeaders;
               if (config.TmdbApiKey)
                 document.getElementById("tmdbKey").value = config.TmdbApiKey;
               if (config.RpdbApiKey) {
@@ -1674,7 +1705,6 @@
                 config.EnableAiCache !== undefined ||
                 config.TraktAccessToken ||
                 config.GeminiModel ||
-                config.OpenAICompatModel ||
                 config.EnableRpdb // Check the new flag too
               ) {
                 document.getElementById("showAdvancedOptions").checked = true;

--- a/public/configure.html
+++ b/public/configure.html
@@ -545,6 +545,23 @@
       <form id="configForm">
         <!-- Basic Configuration (Always Visible) -->
         <div class="form-group">
+          <label class="form-label" for="aiProvider"
+            >AI Provider <span class="required">*</span></label
+          >
+          <select id="aiProvider" class="form-select">
+            <option value="gemini" selected>Gemini (Google AI Studio)</option>
+            <option value="openai-compat">
+              OpenAI-compatible (OpenAI / OpenRouter / Z.ai / etc.)
+            </option>
+          </select>
+          <div class="help-text">
+            Choose either a Gemini-compatible model or any OpenAI-compatible
+            endpoint.
+          </div>
+        </div>
+
+        <div id="geminiFields">
+        <div class="form-group">
           <label class="form-label" for="geminiKey"
             >Gemini API Key <span class="required">*</span></label
           >
@@ -558,6 +575,59 @@
             <a href="https://makersuite.google.com/app/apikey" target="_blank"
               >Google AI Studio</a
             >
+          </div>
+        </div>
+        </div>
+
+        <div id="openaiCompatFields" style="display: none;">
+          <div class="form-group">
+            <label class="form-label" for="openaiCompatApiKey"
+              >OpenAI-Compatible API Key <span class="required">*</span></label
+            >
+            <input
+              type="password"
+              id="openaiCompatApiKey"
+              placeholder="Enter your API key (OpenAI/OpenRouter/Z.ai/etc.)"
+            />
+            <div class="help-text">
+              Works with any OpenAI-compatible provider. For OpenRouter, use an
+              API key from
+              <a href="https://openrouter.ai/keys" target="_blank">OpenRouter</a
+              >.
+            </div>
+          </div>
+
+          <div class="form-group">
+            <label class="form-label" for="openaiCompatModel"
+              >Model <span class="required">*</span></label
+            >
+            <input
+              type="text"
+              id="openaiCompatModel"
+              placeholder="e.g., gpt-4o-mini or openai/gpt-4o-mini"
+              value="gpt-4o-mini"
+            />
+            <div class="help-text">
+              Use a model name supported by your provider (OpenRouter uses names
+              like <code>openai/gpt-4o-mini</code>).
+            </div>
+          </div>
+
+          <div class="form-group">
+            <label class="form-label" for="openaiCompatBaseUrl"
+              >Base URL (Optional)</label
+            >
+            <input
+              type="text"
+              id="openaiCompatBaseUrl"
+              placeholder="Default: https://api.openai.com"
+            />
+            <div class="help-text">
+              Examples:
+              <code>https://api.openai.com</code>,
+              <code>https://openrouter.ai/api</code>,
+              <code>https://openrouter.ai/api/v1</code>
+            </div>
           </div>
         </div>
 
@@ -824,7 +894,7 @@
             </div>
           </div>
 
-          <div class="form-group">
+          <div class="form-group" id="geminiModelGroup">
             <label class="form-label" for="geminiModel"
               >Gemini Model Name</label
             >
@@ -1096,7 +1166,15 @@
 
       // Remove the old key masking functions and setup
       function setupKeyHandling() {
-        const keyInputs = ["geminiKey", "tmdbKey", "rpdbKey", "fanartKey"];
+        const keyInputs = [
+          "geminiKey",
+          "openaiCompatApiKey",
+          "openaiCompatModel",
+          "openaiCompatBaseUrl",
+          "tmdbKey",
+          "rpdbKey",
+          "fanartKey",
+        ];
 
         keyInputs.forEach((inputId) => {
           const input = document.getElementById(inputId);
@@ -1116,13 +1194,34 @@
       });
 
       window.getAddonUrl = async function () {
+        const aiProvider = document.getElementById("aiProvider").value;
         const geminiKey = document.getElementById("geminiKey").value.trim();
+        const openaiCompatApiKey = document
+          .getElementById("openaiCompatApiKey")
+          .value.trim();
+        const openaiCompatModel = document
+          .getElementById("openaiCompatModel")
+          .value.trim();
+        const openaiCompatBaseUrl = document
+          .getElementById("openaiCompatBaseUrl")
+          .value.trim();
         const tmdbKey = document.getElementById("tmdbKey").value.trim();
         
         // Basic validation
-        if (!geminiKey || geminiKey.length < 10) {
-          showError("Please enter a valid Gemini API key");
-          return null;
+        if (aiProvider === "gemini") {
+          if (!geminiKey || geminiKey.length < 10) {
+            showError("Please enter a valid Gemini API key");
+            return null;
+          }
+        } else {
+          if (!openaiCompatApiKey || openaiCompatApiKey.length < 10) {
+            showError("Please enter a valid OpenAI-compatible API key");
+            return null;
+          }
+          if (!openaiCompatModel) {
+            showError("Please enter a model name");
+            return null;
+          }
         }
         if (!tmdbKey || tmdbKey.length < 10) {
           showError("Please enter a valid TMDB API key");
@@ -1131,7 +1230,14 @@
 
         try {
           setLoading(true);
-          const isValid = await validateApiKeys(geminiKey, tmdbKey);
+          const isValid = await validateApiKeys({
+            aiProvider,
+            geminiKey,
+            openaiCompatApiKey,
+            openaiCompatModel,
+            openaiCompatBaseUrl,
+            tmdbKey,
+          });
           if (!isValid) return null;
           clearError();
 
@@ -1139,19 +1245,27 @@
 
           // 1. Prepare the main configuration object
           const configData = {
-            GeminiApiKey: geminiKey,
+            AiProvider: aiProvider,
             TmdbApiKey: tmdbKey,
             RpdbApiKey: document.getElementById("rpdbKey").value.trim(),
             FanartApiKey: document.getElementById("fanartKey").value.trim(),
             NumResults: parseInt(document.getElementById("numResults").value.trim()) || 20,
             EnableAiCache: document.getElementById("enableAiCache").checked,
             TmdbLanguage: document.getElementById("tmdbLanguage").value,
-            GeminiModel: document.getElementById("geminiModel").value,
             EnableRpdb: document.getElementById("enableRpdbPosters").checked,
             EnableHomepage: document.getElementById("enableHomepage").checked,
             IncludeAdult: document.getElementById("includeAdult").checked,
             EnableSimilar: document.getElementById("enableSimilar").checked,
           };
+
+          if (aiProvider === "gemini") {
+            configData.GeminiApiKey = geminiKey;
+            configData.GeminiModel = document.getElementById("geminiModel").value;
+          } else {
+            configData.OpenAICompatApiKey = openaiCompatApiKey;
+            configData.OpenAICompatModel = openaiCompatModel;
+            if (openaiCompatBaseUrl) configData.OpenAICompatBaseUrl = openaiCompatBaseUrl;
+          }
 
           // Add conditional properties
           if (configData.EnableHomepage && document.getElementById("homepageQuery").value.trim()) {
@@ -1211,7 +1325,14 @@
         }
       };
 
-      async function validateApiKeys(geminiKey, tmdbKey) {
+      async function validateApiKeys({
+        aiProvider,
+        geminiKey,
+        openaiCompatApiKey,
+        openaiCompatModel,
+        openaiCompatBaseUrl,
+        tmdbKey,
+      }) {
         const errorDiv = document.getElementById("error");
         const traktAccessToken = document
           .getElementById("traktAccessToken")
@@ -1228,7 +1349,11 @@
               "Content-Type": "application/json",
             },
             body: JSON.stringify({
+              AiProvider: aiProvider,
               GeminiApiKey: geminiKey,
+              OpenAICompatApiKey: openaiCompatApiKey,
+              OpenAICompatModel: openaiCompatModel,
+              OpenAICompatBaseUrl: openaiCompatBaseUrl,
               TmdbApiKey: tmdbKey,
               FanartApiKey: fanartKey,
               TraktAccessToken: traktAccessToken,
@@ -1238,9 +1363,10 @@
 
           const result = await response.json();
 
-          if (!result.gemini || !result.tmdb) {
+          const aiOk = !!(result.ai || result.gemini || result.openaiCompat);
+          if (!aiOk || !result.tmdb) {
             errorDiv.style.display = "block";
-            errorDiv.textContent = Object.values(result.errors).join(". ");
+            errorDiv.textContent = Object.values(result.errors || {}).join(". ");
             return false;
           }
 
@@ -1317,7 +1443,19 @@
       */
 
       // Update input change handlers to not automatically clear errors
+      document.getElementById("aiProvider").addEventListener("change", () => {
+        document.getElementById("manual-url").style.display = "none";
+      });
       document.getElementById("geminiKey").addEventListener("input", () => {
+        document.getElementById("manual-url").style.display = "none";
+      });
+      document.getElementById("openaiCompatApiKey").addEventListener("input", () => {
+        document.getElementById("manual-url").style.display = "none";
+      });
+      document.getElementById("openaiCompatModel").addEventListener("input", () => {
+        document.getElementById("manual-url").style.display = "none";
+      });
+      document.getElementById("openaiCompatBaseUrl").addEventListener("input", () => {
         document.getElementById("manual-url").style.display = "none";
       });
       document.getElementById("tmdbKey").addEventListener("input", () => {
@@ -1361,6 +1499,17 @@
         homepageQueryGroup.style.display = enableHomepage ? 'block' : 'none';
       }
 
+      function toggleAiProviderVisibility() {
+        const provider = document.getElementById("aiProvider").value;
+        const geminiFields = document.getElementById("geminiFields");
+        const openaiCompatFields = document.getElementById("openaiCompatFields");
+        const geminiModelGroup = document.getElementById("geminiModelGroup");
+
+        if (geminiFields) geminiFields.style.display = provider === "gemini" ? "block" : "none";
+        if (openaiCompatFields) openaiCompatFields.style.display = provider === "openai-compat" ? "block" : "none";
+        if (geminiModelGroup) geminiModelGroup.style.display = provider === "gemini" ? "block" : "none";
+      }
+
       // Initialize the advanced section to be hidden on page load
       document.addEventListener("DOMContentLoaded", function () {
         document.getElementById("advancedOptions").style.display = "none";
@@ -1376,6 +1525,10 @@
         // Show/hide homepage query input based on checkbox state
         toggleHomepageQueryVisibility(); // Set initial state on load
         document.getElementById('enableHomepage').addEventListener('change', toggleHomepageQueryVisibility);
+
+        // Show/hide provider-specific fields
+        toggleAiProviderVisibility();
+        document.getElementById("aiProvider").addEventListener("change", toggleAiProviderVisibility);
 
         // Check if we're in edit mode (URL contains a config ID)
         const path = window.location.pathname;
@@ -1427,9 +1580,26 @@
               console.log("Loaded configuration:", config);
 
               // Pre-fill the form with the existing configuration
+              if (config.AiProvider) {
+                document.getElementById("aiProvider").value = config.AiProvider;
+              } else if (config.OpenAICompatApiKey && !config.GeminiApiKey) {
+                // Backwards-compatible detection for configs created before AiProvider existed
+                document.getElementById("aiProvider").value = "openai-compat";
+              }
+              toggleAiProviderVisibility();
+
               if (config.GeminiApiKey)
                 document.getElementById("geminiKey").value =
                   config.GeminiApiKey;
+              if (config.OpenAICompatApiKey)
+                document.getElementById("openaiCompatApiKey").value =
+                  config.OpenAICompatApiKey;
+              if (config.OpenAICompatModel)
+                document.getElementById("openaiCompatModel").value =
+                  config.OpenAICompatModel;
+              if (config.OpenAICompatBaseUrl)
+                document.getElementById("openaiCompatBaseUrl").value =
+                  config.OpenAICompatBaseUrl;
               if (config.TmdbApiKey)
                 document.getElementById("tmdbKey").value = config.TmdbApiKey;
               if (config.RpdbApiKey) {
@@ -1504,6 +1674,7 @@
                 config.EnableAiCache !== undefined ||
                 config.TraktAccessToken ||
                 config.GeminiModel ||
+                config.OpenAICompatModel ||
                 config.EnableRpdb // Check the new flag too
               ) {
                 document.getElementById("showAdvancedOptions").checked = true;

--- a/utils/aiProvider.js
+++ b/utils/aiProvider.js
@@ -1,0 +1,151 @@
+let fetchFn = globalThis.fetch;
+if (!fetchFn) {
+  try {
+    const nodeFetch = require("node-fetch");
+    fetchFn = nodeFetch.default || nodeFetch;
+  } catch {
+    // If neither global fetch nor node-fetch exists, callers will get a clear error at runtime.
+    fetchFn = null;
+  }
+}
+
+const fetch = fetchFn ? fetchFn.bind(globalThis) : null;
+
+function normalizeProviderName(provider) {
+  if (!provider) return null;
+  const normalized = String(provider).trim().toLowerCase();
+  if (normalized === "gemini" || normalized === "google") return "gemini";
+  if (
+    normalized === "openai" ||
+    normalized === "openai-compat" ||
+    normalized === "openai_compat" ||
+    normalized === "openai-compatible" ||
+    normalized === "openrouter" ||
+    normalized === "zai"
+  ) {
+    return "openai-compat";
+  }
+  return null;
+}
+
+function getOpenAIChatCompletionsUrl(baseUrl) {
+  const raw = (baseUrl || "").trim().replace(/\/+$/, "");
+  if (!raw) return "https://api.openai.com/v1/chat/completions";
+  if (raw.includes("/chat/completions")) return raw;
+  if (raw.endsWith("/v1")) return `${raw}/chat/completions`;
+  return `${raw}/v1/chat/completions`;
+}
+
+function getAiProviderConfigFromConfig(configData = {}) {
+  const provider = normalizeProviderName(configData.AiProvider);
+
+  if (provider === "openai-compat") {
+    return {
+      provider: "openai-compat",
+      apiKey: (configData.OpenAICompatApiKey || "").trim(),
+      baseUrl: (configData.OpenAICompatBaseUrl || "").trim(),
+      model: (configData.OpenAICompatModel || "gpt-4o-mini").trim(),
+    };
+  }
+
+  if (provider === "gemini") {
+    return {
+      provider: "gemini",
+      apiKey: (configData.GeminiApiKey || "").trim(),
+      model: (configData.GeminiModel || "gemini-2.5-flash-lite").trim(),
+    };
+  }
+
+  // Backwards compatibility: older configs only had Gemini fields.
+  const hasGeminiKey = !!(configData.GeminiApiKey && String(configData.GeminiApiKey).trim());
+  const hasOpenAICompatKey = !!(
+    configData.OpenAICompatApiKey && String(configData.OpenAICompatApiKey).trim()
+  );
+
+  if (hasOpenAICompatKey && !hasGeminiKey) {
+    return {
+      provider: "openai-compat",
+      apiKey: String(configData.OpenAICompatApiKey).trim(),
+      baseUrl: (configData.OpenAICompatBaseUrl || "").trim(),
+      model: (configData.OpenAICompatModel || "gpt-4o-mini").trim(),
+    };
+  }
+
+  return {
+    provider: "gemini",
+    apiKey: (configData.GeminiApiKey || "").trim(),
+    model: (configData.GeminiModel || "gemini-2.5-flash-lite").trim(),
+  };
+}
+
+function createAiTextGenerator(aiProviderConfig) {
+  if (!aiProviderConfig || !aiProviderConfig.provider) {
+    throw new Error("AI provider configuration is missing");
+  }
+
+  if (aiProviderConfig.provider === "gemini") {
+    return {
+      provider: "gemini",
+      model: aiProviderConfig.model,
+      async generateText(prompt) {
+        const { GoogleGenerativeAI } = require("@google/generative-ai");
+        const genAI = new GoogleGenerativeAI(aiProviderConfig.apiKey);
+        const model = genAI.getGenerativeModel({ model: aiProviderConfig.model });
+        const aiResult = await model.generateContent(prompt);
+        return aiResult.response.text().trim();
+      },
+    };
+  }
+
+  if (aiProviderConfig.provider === "openai-compat") {
+    return {
+      provider: "openai-compat",
+      model: aiProviderConfig.model,
+      async generateText(prompt) {
+        if (!fetch) {
+          throw new Error(
+            "Fetch API is not available (need Node 18+ or install node-fetch)"
+          );
+        }
+        const url = getOpenAIChatCompletionsUrl(aiProviderConfig.baseUrl);
+        const response = await fetch(url, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${aiProviderConfig.apiKey}`,
+          },
+          body: JSON.stringify({
+            model: aiProviderConfig.model,
+            messages: [{ role: "user", content: prompt }],
+            temperature: 0.2,
+          }),
+        });
+
+        if (!response.ok) {
+          const errorText = await response.text().catch(() => "");
+          const error = new Error(
+            `OpenAI-compatible API error (Status: ${response.status})${errorText ? `: ${errorText}` : ""}`
+          );
+          error.status = response.status;
+          throw error;
+        }
+
+        const data = await response.json();
+        const content =
+          data?.choices?.[0]?.message?.content ??
+          data?.choices?.[0]?.text ??
+          "";
+
+        return String(content).trim();
+      },
+    };
+  }
+
+  throw new Error(`Unsupported AI provider: ${aiProviderConfig.provider}`);
+}
+
+module.exports = {
+  createAiTextGenerator,
+  getAiProviderConfigFromConfig,
+  getOpenAIChatCompletionsUrl,
+};


### PR DESCRIPTION
## Summary
Adds a configurable AI provider switch so the addon can use either:
- **Gemini-compatible** models (existing behavior)
- **OpenAI-compatible** endpoints (OpenAI / OpenRouter / Z.ai / etc.)

This lets users choose between provider ecosystems without changing addon logic.

## What changed
- Added provider abstraction + OpenAI-compatible Chat Completions adapter (`utils/aiProvider.js`)
- Updated addon AI calls to use the selected provider (`addon.js`)
- Updated `/aisearch/validate` to validate the selected provider (`server.js`)
- Updated configuration UI to select provider + show relevant fields (`public/configure.html`)
- Updated docs/landing copy to reflect provider choice (`README.md`, `index.html`)

## Configuration
### Gemini
- Provider: `gemini`
- Key: Google AI Studio key
- Model: e.g. `gemini-2.5-flash-lite`

### OpenAI-compatible
- Provider: `openai-compat`
- Key: provider API key
- Base URL examples:
  - `https://api.openai.com`
  - `https://openrouter.ai/api` (or `https://openrouter.ai/api/v1`)
- Model examples:
  - `gpt-4o-mini`
  - `openai/gpt-4o-mini` (OpenRouter-style)

## Backwards compatibility
- Existing configs without `AiProvider` continue to default to Gemini.

## Test plan
- [ ] Configure with **Gemini** (key + model) and verify a search query returns results
- [ ] Configure with **OpenAI-compatible** (key + base URL + model) and verify a search query returns results
- [ ] Verify `/aisearch/validate` succeeds for the selected provider

## Notes
- OpenAI-compatible integration uses the Chat Completions endpoint (`/v1/chat/completions`).
