### PR TITLE
Add Docker and docker-compose support for self-hosting

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,17 @@
-FROM node:23
+FROM node:20-alpine
+
 WORKDIR /usr/src/app
-COPY package*.json ./
-RUN npm install
-COPY . .
-EXPOSE 7000
+
 ENV NODE_ENV=production
 ENV ENABLE_LOGGING=false
+
+COPY package*.json ./
+RUN npm install --production
+
+COPY . .
+
+EXPOSE 7000
+
 RUN mkdir -p logs
-CMD ["node", "server.js"] 
+
+CMD ["node", "server.js"]

--- a/README.md
+++ b/README.md
@@ -454,6 +454,17 @@ Here are some examples showing how versatile this addon is.
 
 ## Self Hosting
 
+### Docker (Recommended)
+
+#### Requirements
+- Docker
+- Docker Compose
+
+#### Run with Docker Compose
+
+```bash
+docker compose up --build
+
 ### Environment Variables
 
 When self-hosting the addon, you can configure the following environment variables in a `.env` file:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: "3.8"
+
+services:
+  stremio-ai-search:
+    build: .
+    container_name: stremio-ai-search
+    restart: unless-stopped
+    ports:
+      - "7000:7000"
+    environment:
+      NODE_ENV: production
+      ENABLE_LOGGING: "false"
+      # Add API keys if required by the app
+      # TMDB_API_KEY: your_key_here
+      # GEMINI_API_KEY: your_key_here


### PR DESCRIPTION
FIXES #158 
This PR adds Docker support for self-hosting the Stremio AI Search addon.

Changes:
- Added production-ready Dockerfile
- Added docker-compose.yml for easy self-hosting
- Updated README with Docker usage instructions

